### PR TITLE
app: axios 의존성 분리와 http통신할 때 accessToken을 담아서 호출하도록 수정

### DIFF
--- a/app/src/api/http-client.js
+++ b/app/src/api/http-client.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { getStorage } from './support';
+
+// TODO: move to config
+const SERVER_URL = 'http://localhost:4000';
+
+const api = axios.create({
+  baseURL: SERVER_URL,
+});
+
+const setAccessToken = () => {
+  const accessToken = getStorage('ACCESS_TOKEN');
+  if (accessToken) {
+    api.defaults.headers.Authorization = `${accessToken}`;
+  } else {
+    delete api.defaults.headers.Authorization;
+  }
+};
+
+const httpClient = {
+  async get({ url, params, responseType }) {
+    setAccessToken();
+    return api({
+      method: 'GET',
+      url,
+      params,
+      responseType,
+    });
+  },
+  async post({ url, headers, data }) {
+    setAccessToken();
+    return api({
+      method: 'POST',
+      headers,
+      url,
+      data,
+    });
+  },
+  async delete({ url, data }) {
+    setAccessToken();
+    return api({
+      method: 'DELETE',
+      url,
+      data,
+    });
+  },
+  async put({ url, data }) {
+    setAccessToken();
+    return api({
+      method: 'PUT',
+      url,
+      data,
+    });
+  },
+};
+
+export default httpClient;

--- a/app/src/api/support.js
+++ b/app/src/api/support.js
@@ -1,0 +1,12 @@
+const setStorage = (key, value) => {
+  return localStorage.setItem(key, value);
+};
+
+const getStorage = (key) => {
+  return localStorage.getItem(key);
+};
+
+module.exports = {
+  setStorage,
+  getStorage,
+};

--- a/app/src/pages/Login.jsx
+++ b/app/src/pages/Login.jsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
+import { setStorage } from '../api/support';
+
 function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -11,6 +13,11 @@ function Login() {
       email,
       password,
     });
+
+    if (result?.data?.accessToken) {
+      const accessToken = result?.data?.accessToken;
+      setStorage('ACCESS_TOKEN', accessToken);
+    }
   };
 
   return (

--- a/app/src/socket/http-test.js
+++ b/app/src/socket/http-test.js
@@ -1,48 +1,51 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import httpClient from '../api/http-client';
 
 const HttpTest = () => {
   const [rooms, setRooms] = useState([]);
   const [members, setMembers] = useState([]);
 
   const findRooms = async () => {
-    const result = await axios.get('http://localhost:4000/rooms');
+    const result = await httpClient.get({ url: `/rooms` });
     console.log('rooms', result);
     setRooms(result.data);
   };
 
   const findMembers = async () => {
-    const result = await axios.get('http://localhost:4000/members');
+    const result = await httpClient.get({ url: `/members` });
     console.log('members', result);
     setMembers(result.data);
   };
 
   const findGroups = async () => {
-    const result = await axios.get('http://localhost:4000/groups');
+    const result = await httpClient.get({ url: `/groups` });
     console.log('groups', result);
   };
 
   const findDesks = async () => {
     const roomId = 1;
-    const result = await axios.get(`http://localhost:4000/desks/${roomId}`);
+    const result = await httpClient.get({ url: `/desks/${roomId}` });
     console.log('desks', result);
   };
 
   const findParts = async () => {
     const roomId = 1;
-    const result = await axios.get(`http://localhost:4000/parts/${roomId}`);
+    const result = await httpClient.get({ url: `/parts/${roomId}` });
     console.log('parts', result);
   };
 
   const findGroupMembers = async () => {
-    const result = await axios.get('http://localhost:4000/groups/members');
+    const result = await httpClient.get({ url: `/members` });
     console.log('groups', result);
   };
 
   const signIn = async () => {
-    const result = await axios.post('http://localhost:4000/auth/sign-in', {
-      email: 'test',
-      password: 'test',
+    const result = await httpClient.post({
+      url: `/auth/sign-in`,
+      data: {
+        email: 'test',
+        password: 'test',
+      },
     });
   };
 


### PR DESCRIPTION
* httpClient.js (의존성 분리 + 통신할 때 accessToken을 담아서 요청)

```
Login -> accessToken을 localStorage에 저장 -> http요청할 때 accessToken을 담아서 호출
```

> 프론트 로그인쪽 개발이 완료되면 `auth/sign-in`을 제외하고는 토큰 없이는 통신할 수 없도록 변경될 예정입니다.