### PR TITLE
api, app: endpoint path 오류 수정

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -17,7 +17,7 @@ const PORT = 3000;
 http.listen(PORT, () => {
   console.log("listening on *:" + PORT);
 });
-app.use(require("./routes"));
+app.use("/.api", require("./routes"));
 app.get("/", (req, res) => {
   res.send("socket.io");
 });

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -46,7 +46,6 @@ module.exports = {
     proxy: {
       '/.api': {
         target: 'http://localhost:3000',
-        pathRewrite: { '^/.api': '' },
       },
     },
   },


### PR DESCRIPTION
* webpack-dev-server로는 정상 동작하지만 build된 코드로 접속하면 api를 못불러오는 오류